### PR TITLE
[BUGFIX] Add page uid to rte module urls for correct TSconfig loading

### DIFF
--- a/Classes/Form/Element/RichTextElement.php
+++ b/Classes/Form/Element/RichTextElement.php
@@ -662,6 +662,7 @@ class RichTextElement extends AbstractFormElement
         $jsArray[] = 'editornumber = ' . GeneralUtility::quoteJSvalue($this->domIdentifier) . ';';
         $jsArray[] = 'RTEarea[editornumber] = new Object();';
         $jsArray[] = 'RTEarea[editornumber].RTEtsConfigParams = "&RTEtsConfigParams=' . rawurlencode($this->RTEtsConfigParams()) . '";';
+        $jsArray[] = 'RTEarea[editornumber].uidOfPageRecord = "&id=' . (int)$this->pidOfPageRecord . '";';
         $jsArray[] = 'RTEarea[editornumber].number = editornumber;';
         $jsArray[] = 'RTEarea[editornumber].deleted = false;';
         $jsArray[] = 'RTEarea[editornumber].textAreaId = ' . GeneralUtility::quoteJSvalue($this->domIdentifier) . ';';

--- a/Resources/Public/JavaScript/HTMLArea/Plugin/Plugin.js
+++ b/Resources/Public/JavaScript/HTMLArea/Plugin/Plugin.js
@@ -453,7 +453,7 @@ define([
 		 * @return {String} The url
 		 */
 		makeUrlFromModulePath: function (modulePath, parameters) {
-			return modulePath + (modulePath.indexOf("?") === -1 ? "?" : "&") + this.editorConfiguration.RTEtsConfigParams + '&editorNo=' + this.editor.editorId + '&sys_language_content=' + this.editorConfiguration.sys_language_content + '&contentTypo3Language=' + this.editorConfiguration.typo3ContentLanguage + (parameters?parameters:'');
+			return modulePath + (modulePath.indexOf("?") === -1 ? "?" : "&") + this.editorConfiguration.uidOfPageRecord + this.editorConfiguration.RTEtsConfigParams + '&editorNo=' + this.editor.editorId + '&sys_language_content=' + this.editorConfiguration.sys_language_content + '&contentTypo3Language=' + this.editorConfiguration.typo3ContentLanguage + (parameters?parameters:'');
 		},
 
 		/**


### PR DESCRIPTION
Because of a missing page uid in rte module window iframe urls, like for
the BrowseLinks popup, the ConditionMatcher could not evaluate
conditions in INCLUDE_TYPOSCRIPT that rely on the page uid, like
PIDinRootline.

Resolves: https://forge.typo3.org/issues/81190