### PR TITLE
[BUGFIX] Remove deprecated code

### DIFF
--- a/Classes/Form/Element/RichTextElement.php
+++ b/Classes/Form/Element/RichTextElement.php
@@ -330,16 +330,12 @@ class RichTextElement extends AbstractFormElement
             $result[] =     '</textarea>';
             $result[] = '</div>';
         } else {
-            $legacyWizards = $this->renderWizards();
-            $legacyFieldControlHtml = implode(LF, $legacyWizards['fieldControl']);
-            $legacyFieldWizardHtml = implode(LF, $legacyWizards['fieldWizard']);
-
             $fieldControlResult = $this->renderFieldControl();
-            $fieldControlHtml = $legacyFieldControlHtml . $fieldControlResult['html'];
+            $fieldControlHtml =  $fieldControlResult['html'];
             $this->resultArray = $this->mergeChildReturnIntoExistingResult($this->resultArray, $fieldControlResult, false);
 
             $fieldWizardResult = $this->renderFieldWizard();
-            $fieldWizardHtml = $legacyFieldWizardHtml . $fieldWizardResult['html'];
+            $fieldWizardHtml = $fieldWizardResult['html'];
             $this->resultArray = $this->mergeChildReturnIntoExistingResult($this->resultArray, $fieldWizardResult, false);
 
             $result[] = '<div class="formengine-field-item t3js-formengine-field-item">';


### PR DESCRIPTION
ClientUtility::getVersion() && ClientUtility::getBrowserInfo() are deprecated in TYPO3 and should not be used anymore. In rtehtmlarea the client information was used to distinguish old Internet Explorer Versions from other browsers when setting width. Modern Internet Explorer versions support it the same way other browsers did and the distinction is therefor not necessary anymore.