### PR TITLE
[BUGFIX] Add page uid to link browser tabs for correct TSconfig loading

### DIFF
--- a/Classes/Controller/BrowseLinksController.php
+++ b/Classes/Controller/BrowseLinksController.php
@@ -605,7 +605,8 @@ class BrowseLinksController extends AbstractLinkBrowserController
             'act' => isset($overrides['act']) ? $overrides['act'] : $this->displayedLinkHandlerId,
             'bparams' => $this->bparams,
             'editorNo' => $this->editorNo,
-            'contentTypo3Language' => $this->contentTypo3Language
+            'contentTypo3Language' => $this->contentTypo3Language,
+            'id' => $this->getCurrentPageId()
         ];
     }
 }


### PR DESCRIPTION
This is a follow up to ea4d2a5. Because of a missing page uid
parameter in links to other linkHandler types the ConditionMatcher
could not evaluate conditions in INCLUDE_TYPOSCRIPT that rely on the
page uid, like PIDinRootline, if the user changes the type in the
link browser modal.