### PR TITLE
Fix "TypeError: caption is undefined"

### DIFF
--- a/Resources/Public/JavaScript/Plugins/TableOperations.js
+++ b/Resources/Public/JavaScript/Plugins/TableOperations.js
@@ -1690,7 +1690,7 @@ define([
 				$('<div />', {'class': 'form-group'}).append(
 					$('<label />', {'class': 'col-sm-2'}).html(this.getHelpTip('caption', 'Caption:')),
 					$('<div />', {'class': 'col-sm-10'}).append(
-						$('<input />', {name: 'f_caption', 'class': 'form-control', value: (caption ? caption.innerHTML : '')})
+						$('<input />', {name: 'f_caption', 'class': 'form-control', value: (typeof caption === 'object' && caption ? caption.innerHTML : '')})
 					)
 				),
 				$('<div />', {'class': 'form-group'}).append(


### PR DESCRIPTION
Error is triggered when trying to open the "Table properties" modale for a table created without caption