### PR TITLE
[BUGFIX] Use non-JavaScript based iframe src

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
+++ b/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
@@ -214,7 +214,7 @@ define(['TYPO3/CMS/Rtehtmlarea/HTMLArea/UserAgent/UserAgent',
 						id: this.editorId + '-iframe',
 						tag: 'iframe',
 						cls: 'editorIframe',
-						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? 'javascript: \'' + Util.htmlEncode(this.config.documentType + this.config.blankDocument) + '\'' : HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
+						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? 'about:blank;' : HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
 					},
 					isNested: this.isNested,
 					nestedParentElements: this.nestedParentElements,


### PR DESCRIPTION
Since the release of Chrome 73, iframe documents can't be loaded via
javascript protocol anymore. This commit changes the iframe src to
be an empty page for WebKit browsers.

Many thanks go to @guppy42 who identified the cause and proposed this fix.

Resolves: #26