### PR TITLE
[BUGFIX] Do not use about:blank as src in other Webkit browsers than Chrome

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
+++ b/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
@@ -214,7 +214,7 @@ define(['TYPO3/CMS/Rtehtmlarea/HTMLArea/UserAgent/UserAgent',
 						id: this.editorId + '-iframe',
 						tag: 'iframe',
 						cls: 'editorIframe',
-						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? 'about:blank;' : HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
+						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? (UserAgent.isChrome ? 'about:blank;' : 'javascript: \'' + Util.htmlEncode(this.config.documentType + this.config.blankDocument) + '\'' ): HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
 					},
 					isNested: this.isNested,
 					nestedParentElements: this.nestedParentElements,


### PR DESCRIPTION
Only Chrome needs `about:blank` as iframe src as introduced in #28. Safari
can't handle this and treats `about:blank` as a cross origin.

Resolves: #30
Related: #26