### PR TITLE
Set the iFrame src to javascript:void(0); when Safari

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
+++ b/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
@@ -214,7 +214,7 @@ define(['TYPO3/CMS/Rtehtmlarea/HTMLArea/UserAgent/UserAgent',
 						id: this.editorId + '-iframe',
 						tag: 'iframe',
 						cls: 'editorIframe',
-						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? (UserAgent.isChrome ? 'about:blank;' : 'javascript: \'' + Util.htmlEncode(this.config.documentType + this.config.blankDocument) + '\'' ): HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
+						src: UserAgent.isSafari ? 'javascript:void(0);' : (UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? (UserAgent.isChrome ? 'about:blank;' : 'javascript: \'' + Util.htmlEncode(this.config.documentType + this.config.blankDocument) + '\'' ): HTMLArea.editorUrl + 'Resources/Public/Html/blank.html'))
 					},
 					isNested: this.isNested,
 					nestedParentElements: this.nestedParentElements,


### PR DESCRIPTION
Fix the problem loading the htmlArea with the newest Safari 12.1.2 (13607.3.10) on Mac OS