### PR TITLE
[BUGFIX] Set empty iframe src for Webkit and Chrome

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
+++ b/Resources/Public/JavaScript/HTMLArea/Editor/Editor.js
@@ -214,7 +214,7 @@ define(['TYPO3/CMS/Rtehtmlarea/HTMLArea/UserAgent/UserAgent',
 						id: this.editorId + '-iframe',
 						tag: 'iframe',
 						cls: 'editorIframe',
-						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit ? (UserAgent.isChrome ? 'about:blank;' : 'javascript: \'' + Util.htmlEncode(this.config.documentType + this.config.blankDocument) + '\'' ): HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
+						src: UserAgent.isGecko ? 'javascript:void(0);' : (UserAgent.isWebKit || UserAgent.isChrome ? '' : HTMLArea.editorUrl + 'Resources/Public/Html/blank.html')
 					},
 					isNested: this.isNested,
 					nestedParentElements: this.nestedParentElements,


### PR DESCRIPTION
Safari begun to block the "HTML as source" features used in HTMLArea,
similar as Chrome did some months ago.

This patch now enforces an empty src attribute for Webkit and Chrome.

Background information:
- This patch is tested against Safari in macOS Mojave and OS X Yosemite
- This patch is a forward port of the ELTS bugfix

Resolves: #26