### PR TITLE
#35 Bugfix: Added name attributes to select fields

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Components/Select.js
+++ b/Resources/Public/JavaScript/HTMLArea/Components/Select.js
@@ -48,6 +48,9 @@ define([
 			if (this.id) {
 				this.selectElement.setAttribute('id', this.id);
 			}
+			if (this.name) {
+				this.selectElement.setAttribute('name', this.name);
+			}
 			if (typeof this.cls === 'string') {
 				Dom.addClass(this.selectElement, this.cls);
 			}

--- a/Resources/Public/JavaScript/Plugins/TableOperations.js
+++ b/Resources/Public/JavaScript/Plugins/TableOperations.js
@@ -1824,6 +1824,7 @@ define([
 				{
 					xtype: 'htmlareaselect',
 					itemId: fieldName,
+					name: fieldName,
 					fieldLabel: this.getHelpTip(fieldTitle, fieldLabel),
 					helpTitle: typeof TYPO3.ContextHelp !== 'undefined' ? '' : this.localize(fieldTitle),
 					width: (this.properties['style'] && this.properties['style'].width) ? this.properties['style'].width : 300


### PR DESCRIPTION
Bugfix for Issue #35. The select fields for css class in the table dialog are missing the name attribute.