### PR TITLE
hotfix for error in chrome after ver. 91.0.4472.77

### DIFF
--- a/Resources/Public/JavaScript/HTMLArea/Editor/Iframe.js
+++ b/Resources/Public/JavaScript/HTMLArea/Editor/Iframe.js
@@ -199,7 +199,7 @@ define(['TYPO3/CMS/Rtehtmlarea/HTMLArea/UserAgent/UserAgent',
 					self.initializeIframe();
 				}, 50);
 			// WebKit
-			} else if (UserAgent.isWebKit && (!iframe.contentDocument.documentElement || !iframe.contentDocument.body)) {
+			} else if (UserAgent.isWebKit && (!iframe.contentDocument || !iframe.contentDocument.documentElement || !iframe.contentDocument.body)) {
 				window.setTimeout(function () {
 					self.initializeIframe();
 				}, 50);


### PR DESCRIPTION
This is a hotfix for issue #50

initializeIframe fails with null access on iframe.contentDocument
So we have to check it before accessing it.

I wasn't able to identify the commit on chromium which causes this.

