### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/rtehtmlarea/v/stable.svg)](https://extensions.typo3.org/extension/rtehtmlarea/)
-[![TYPO3](https://img.shields.io/badge/TYPO3-8-orange.svg?style=flat-square)](https://get.typo3.org/version/8)
+[![TYPO3 8](https://img.shields.io/badge/TYPO3-8-orange.svg?style=flat-square)](https://get.typo3.org/version/8)
 [![Total Downloads](https://poser.pugx.org/friendsoftypo3/rtehtmlarea/d/total.svg)](https://packagist.org/packages/friendsoftypo3/rtehtmlarea)
 [![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/rtehtmlarea/d/monthly)](https://packagist.org/packages/friendsoftypo3/rtehtmlarea)
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
 	"name": "friendsoftypo3/rtehtmlarea",
 	"type": "typo3-cms-extension",
 	"description": "Highly configurable RTE based on HtmlArea for TYPO3 v8.",
-	"homepage": "https://github.com/FriendsOfTYPO3/rtehtmlarea",
+	"homepage": "https://extensions.typo3.org/extension/rtehtmlarea",
+	"support": {
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/rtehtmlarea/main/en-us/",
+		"issues": "https://github.com/FriendsOfTYPO3/rtehtmlarea/issues",
+		"source": "https://github.com/FriendsOfTYPO3/rtehtmlarea"
+	},
 	"license": ["GPL-2.0-or-later"],
 	"require": {
 		"typo3/cms-core": "*"


### PR DESCRIPTION
Added new commit regarding additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185